### PR TITLE
Cleanup fr translation

### DIFF
--- a/index.fr.md
+++ b/index.fr.md
@@ -1,6 +1,9 @@
 ---
 title: Principes d’accessibilité
 permalink: /fundamentals/accessibility-principles/fr/
+ref: /fundamentals/accessibility-principles/
+lang: fr
+last_updated: 2018-12-26
 github:
   repository: w3c/wai-accessibility-principles
 layout: default
@@ -11,14 +14,13 @@ footer: >
   <p><strong>Date:</strong> dernière mise à jour de cette traduction le @@DATE.</p>
   <p lang="en"><strong>Editors:</strong> <a href="https://www.w3.org/People/shadi/" hreflang="en">Shadi Abou_Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments" hreflang="en">Acknowledgments</a>.</p>
   <p lang="en">Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/" hreflang="en">EOWG</a>). Previously developed with the <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf" hreflang="en">WAI-AGE Task Force</a>, with support of the <a href="https://www.w3.org/WAI/WAI-AGE/" hreflang="en">WAI-AGE Project</a>.</p>
-
 ---
 
 {::nomarkdown}
 {% include box.html type="start" h="2" title="Résumé" class="full" %}
 {:/}
 
-Cette page introduit certaines exigences d’accessibilité web fondamentales pour les sites et les applications web, les navigateurs et autres outils. Elle fournit des liens vers les standards internationaux de l’Initiative Accessibilité du Web (WAI) du W3C et vers une page parlant des particularités de [quelques utilisateurs du Web]({{ "/people-use-web/user-stories.fr/" | relative_url }}).
+Cette page introduit certaines exigences d’accessibilité web fondamentales pour les sites et les applications web, les navigateurs et autres outils. Elle fournit des liens vers les standards internationaux de l’Initiative Accessibilité du Web (WAI) du W3C et vers une page parlant des particularités de {% include link.html to="/people-use-web/user-stories/" text="quelques utilisateurs du Web" %}.
 
 **Note :** ce n’est pas une liste exhaustive de toutes les exigences d’accessibilité.
 
@@ -49,7 +51,7 @@ Standards d’accessibilité Web {#standards}
 L’accessibilité web s’appuie sur plusieurs composants qui travaillent ensemble. Certains d’entre eux sont :
 
 - **Les contenus web**{:#webcontent} : ce terme s’applique à toute partie d’un site web, y compris le texte, les images, les formulaires et le multimédia, aussi bien que tout code, script, application, et ainsi de suite.
-- **Les agents utilisateurs**{:#useragents} : des logiciels que l’on utilise pour accéder aux contenus web, incluant les navigateurs graphiques de bureau, les navigateurs vocaux, les navigateurs mobiles, les lecteurs multimédia, les <i lang="en">plug-ins</i>, et certaines [technologies d’assistance]({{ "/people-use-web/tools-techniques.fr/" | relative_url }}#at "définition").
+- **Les agents utilisateurs**{:#useragents} : des logiciels que l’on utilise pour accéder aux contenus web, incluant les navigateurs graphiques de bureau, les navigateurs vocaux, les navigateurs mobiles, les lecteurs multimédia, les <i lang="en">plug-ins</i>, et certaines {% include link.html to="/people-use-web/tools-techniques/" text="technologies d’assistance" %}.
 - **Outils de production de contenu**{:#authoringtools} : des logiciels ou des services que l’on utilise pour produit des contenus web, incluant les éditeurs de code, les outils de conversion de documents, les systèmes de gestion de contenus, les blogs, les scripts de bases de données, et d’autres outils.
 
 {% include excol.html type="start" %}
@@ -59,17 +61,17 @@ L’accessibilité web s’appuie sur plusieurs composants qui travaillent ensem
 
 {% include excol.html type="middle" %}
 
-Ces composants sont liés les uns aux autres et se complètent mutuellement. Par exemple, le **contenu web** doit inclure des textes alternatifs pour les images. Cette information doit être interprétée par les **navigateurs web** puis transmise aux **technologies d’assistance**, comme les lecteurs d’écran. Pour créer ces alternatives textuelles, les auteurs ont besoin **d’outils de production de contenus** qui leur permettent de le faire. Plus d’information est disponible dans [Composants essentiels pour l’accessibilité web]({{ "/fundamentals/components.fr/" | relative_url }}).
+Ces composants sont liés les uns aux autres et se complètent mutuellement. Par exemple, le **contenu web** doit inclure des textes alternatifs pour les images. Cette information doit être interprétée par les **navigateurs web** puis transmise aux **technologies d’assistance**, comme les lecteurs d’écran. Pour créer ces alternatives textuelles, les auteurs ont besoin **d’outils de production de contenus** qui leur permettent de le faire. Plus d’information est disponible dans {% include link.html to="/fundamentals/components/" text="Composants essentiels pour l’accessibilité web" %}.
 
-Les standards jouent un rôle vital dans la définition des exigences d’accessibilité pour chacun de ces composants. Certaines exigences d’accessibilité sont facilement atteignables, cependant comprendre les bases du l’usage du Web par des personnes ayant un handicap aide à les mettre en place plus efficacement. Certains aspects de l’accessibilité réclament plus de compétences techniques ou de connaissances expertes de la façon dont les gens utilisent le Web. Dans tous les cas, [impliquer les utilisateurs dès le début et tout le long de vos projets web]({{ "/test-evaluate/involving-users/" | relative_url }}){: hreflang="en"} (en anglais) rendra votre travail plus facile et de meilleure qualité.
+Les standards jouent un rôle vital dans la définition des exigences d’accessibilité pour chacun de ces composants. Certaines exigences d’accessibilité sont facilement atteignables, cependant comprendre les bases du l’usage du Web par des personnes ayant un handicap aide à les mettre en place plus efficacement. Certains aspects de l’accessibilité réclament plus de compétences techniques ou de connaissances expertes de la façon dont les gens utilisent le Web. Dans tous les cas, {% include link.html to="/test-evaluate/involving-users/" text="impliquer les utilisateurs dès le début et tout le long de vos projets web" %} rendra votre travail plus facile et de meilleure qualité.
 
 L’Initiative d’Accessibilité Web (WAI) fournit une liste de recommandations qui sont reconnues internationalement comme le standard pour l’accessibilité web. Elles incluent :
 
--   **[Recommandations d’accessibilité des contenus web (WCAG)]({{ "/standards-guidelines/wcag/" | relative_url }}){: hreflang="en"}** (en anglais)
--   **[Recommandations d’accessibilité des agents utilisateurs (UAAG)]({{ "/standards-guidelines/uaag/" | relative_url }}){: hreflang="en"}** (en anglais)
--   **[Recommandations d’accessibilité des outils de production de contenu (ATAG)]({{ "/standards-guidelines/atag/" | relative_url }}){: hreflang="en"}** (en anglais)
+-   **{% include link.html to="/standards-guidelines/wcag/" text="Recommandations d’accessibilité des contenus web (WCAG)" %}**
+-   **{% include link.html to="/standards-guidelines/uaag/" text="Recommandations d’accessibilité des agents utilisateurs (UAAG)" %}**
+-   **{% include link.html to="/standards-guidelines/atag/" text="Recommandations d’accessibilité des outils de production de contenu (ATAG)" %}**
 
-Il existe aussi une spécification WAI pour les [Applications internet riches accessibles  (WAI-ARIA)](https://www.w3.org/WAI/intro/aria.php){: hreflang="en"}** (en anglais), qui inclut les contenus dynamiques et les contrôles d’interface utilisateur avancés développés avec Ajax, Javascript et d’autres technologies web liées.
+Il existe aussi une spécification WAI pour les **{% include link.html to="/standards-guidelines/aria/" text="Applications internet riches accessibles  (WAI-ARIA)" %}**, qui inclut les contenus dynamiques et les contrôles d’interface utilisateur avancés développés avec Ajax, Javascript et d’autres technologies web liées.
 
 {% include excol.html type="end" %}
 
@@ -96,19 +98,21 @@ Les alternatives textuelles peuvent être présentées sous des formes variées.
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
--   [Guideline 1.1 - Text
+-  [Guideline 1.1 - Text
     Alternatives](http://www.w3.org/WAI/WCAG20/quickref/#text-equiv){: hreflang="en"}
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 1.1 - Alternative
     content](https://www.w3.org/TR/UAAG20/#gl-access-alternative-content){: hreflang="en"}
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -125,7 +129,9 @@ Les alternatives textuelles peuvent être présentées sous des formes variées.
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b){: hreflang="en"}
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}
 
@@ -136,12 +142,12 @@ Les alternatives textuelles peuvent être présentées sous des formes variées.
 
 {% include excol.html type="middle" %}
 
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Martine, étudiante en ligne, malentendante]({{ "/people-use-web/user-stories.fr/" | relative_url }}#onlinestudent)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="onlinestudent" text="Martine, étudiante en ligne, malentendante" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -162,19 +168,21 @@ Des retranscriptions texte bien écrites contenant la séquence correct de toute
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 1.2 - Time-based
     Media](http://www.w3.org/WAI/WCAG20/quickref/#media-equiv)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 1.1 - Alternative
     content](https://www.w3.org/TR/UAAG20/#gl-access-alternative-content)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -189,7 +197,9 @@ Des retranscriptions texte bien écrites contenant la séquence correct de toute
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 {% include excol.html type="end" %}
 {% include excol.html type="start" %}
 
@@ -198,9 +208,9 @@ Des retranscriptions texte bien écrites contenant la séquence correct de toute
 
 {% include excol.html type="middle" %}
 
--   [Martine, étudiante en ligne, malentendante]({{ "/people-use-web/user-stories.fr/" | relative_url }}#onlinestudent)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="onlinestudent" text="Martine, étudiante en ligne, malentendante" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -221,14 +231,16 @@ Pour que les utilisateurs puissent changer la présentatino des contenus, il est
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 1.3 -
     Adaptable](http://www.w3.org/WAI/WCAG20/quickref/#content-structure-separation)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 1.4 - Text
     configuration](https://www.w3.org/TR/UAAG20/#gl-text-config)
@@ -243,7 +255,7 @@ Pour que les utilisateurs puissent changer la présentatino des contenus, il est
 -   [Guideline 1.10 - Element
     Information](https://www.w3.org/TR/UAAG20/#gl-info-link)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -257,7 +269,9 @@ Pour que les utilisateurs puissent changer la présentatino des contenus, il est
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -266,13 +280,13 @@ Pour que les utilisateurs puissent changer la présentatino des contenus, il est
 
 {% include excol.html type="middle" %}
 
--   [Lee, client de site Web marchand, daltonien]({{ "/people-use-web/user-stories.fr/" | relative_url }}#shopper)
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Luis, assistant en supermarché, atteint du syndrome de Down]({{ "/people-use-web/user-stories.fr/" | relative_url }}#supermarketassistant)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="shopper" text="Lee, client de site Web marchand, daltonien" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="supermarketassistant" text="Luis, assistant en supermarché, atteint du syndrome de Down" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -287,7 +301,7 @@ Un contenu perceptible est plus facile à lire et à voir. Par exemple :
 - Les utilisateurs peuvent pauser, arrêter, ou ajuster le volume du son joué sur un site web ;
 - Les sons d’arrière-plan sont bas ou peuvent être coupés, pour éviter toute interférence ou distraction.
 
-Être conforme à cette exigence permet de séparer le premier et l’arrière-plan, de rendre les informations importantes plus faciles à distinguer. Cela intègre aussi bien les besoins de personnes qui n’utilisent pas de technologies d’assistance que de celles utilisant des technologies d’assistance, qui peuvent subir des interférences dues à des éléments audio ou visuels à l’arrière-plan. Par exemple, de nombreuses personnes daltoniennes n’utilisent pas d’outil particulier et s’appuient sur un design correct qui fournit des contrastes suffisants entre le texte et son arrière-plan. Pour d’autres, une piste audio jouée automatiquement peut interférer avec une synthèse vocale ou un outil de [lecture assistée (ALD)](http://www.w3.org/WAI/training/accessible#ald "définition"){: hreflang="en"}.
+Être conforme à cette exigence permet de séparer le premier et l’arrière-plan, de rendre les informations importantes plus faciles à distinguer. Cela intègre aussi bien les besoins de personnes qui n’utilisent pas de technologies d’assistance que de celles utilisant des technologies d’assistance, qui peuvent subir des interférences dues à des éléments audio ou visuels à l’arrière-plan. Par exemple, de nombreuses personnes daltoniennes n’utilisent pas d’outil particulier et s’appuient sur un design correct qui fournit des contrastes suffisants entre le texte et son arrière-plan. Pour d’autres, une piste audio jouée automatiquement peut interférer avec une synthèse vocale ou un outil de [lecture assistée (ALD)](http://www.w3.org/WAI/training/accessible#ald){: hreflang="en"}.
 
 {% include excol.html type="start" %}
 
@@ -296,14 +310,16 @@ Un contenu perceptible est plus facile à lire et à voir. Par exemple :
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 1.4 -
     Distinguishable](http://www.w3.org/WAI/WCAG20/quickref/#visual-audio-contrast)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 1.3 -
     Highlighting](https://www.w3.org/TR/UAAG20/#gl-interaction-highlight)
@@ -322,7 +338,7 @@ Un contenu perceptible est plus facile à lire et à voir. Par exemple :
 -   [Guideline 1.10 - Element
     Information](https://www.w3.org/TR/UAAG20/#gl-info-link)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -333,7 +349,9 @@ Un contenu perceptible est plus facile à lire et à voir. Par exemple :
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -342,11 +360,11 @@ Un contenu perceptible est plus facile à lire et à voir. Par exemple :
 
 {% include excol.html type="middle" %}
 
--   [Lee, client de site Web marchand, daltonien]({{ "/people-use-web/user-stories.fr/" | relative_url }}#shopper)
--   [Martine, étudiante en ligne, malentendante]({{ "/people-use-web/user-stories.fr/" | relative_url }}#onlinestudent)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="shopper" text="Lee, client de site Web marchand, daltonien" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="onlinestudent" text="Martine, étudiante en ligne, malentendante" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -372,14 +390,16 @@ L’accessibilité au clavier comprend :
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 2.1 - Keyboard
     accessible](http://www.w3.org/WAI/WCAG20/quickref/#keyboard-operation)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 2.1 - Keyboard
     access](https://www.w3.org/TR/UAAG20/#gl-keyboard-access)
@@ -390,7 +410,7 @@ L’accessibilité au clavier comprend :
 -   [Guideline 2.11 - Other Input
     Devices](https://www.w3.org/TR/UAAG20/#gl-other-devices)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -401,7 +421,9 @@ L’accessibilité au clavier comprend :
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -410,8 +432,8 @@ L’accessibilité au clavier comprend :
 
 {% include excol.html type="middle" %}
 
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -433,21 +455,23 @@ Là où il faut fournir assez de temps, cela implique de fournir des mécanismes
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 2.2 - Enough
     time](http://www.w3.org/WAI/WCAG20/quickref/#time-limits)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 2.8 - Time-independent
     interaction](https://www.w3.org/TR/UAAG20/#gl-time-independent)
 -   [Guideline 2.10 - Time-based
     media](https://www.w3.org/TR/UAAG20/#gl-control-inaccessible-content)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -457,7 +481,9 @@ Là où il faut fournir assez de temps, cela implique de fournir des mécanismes
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -466,11 +492,11 @@ Là où il faut fournir assez de temps, cela implique de fournir des mécanismes
 
 {% include excol.html type="middle" %}
 
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Luis, assistant en supermarché, atteint du syndrome de Down]({{ "/people-use-web/user-stories.fr/" | relative_url }}#supermarketassistant)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="supermarketassistant" text="Luis, assistant en supermarché, atteint du syndrome de Down" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -485,19 +511,21 @@ Le contenu qui clignote à certaines fréquences ou selon certains schémas peut
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 2.3 -
     Seizures](http://www.w3.org/WAI/WCAG20/quickref/#seizure)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 2.9 -
     Flashing](https://www.w3.org/TR/UAAG20/#gl-prevent-flash)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -508,7 +536,9 @@ Le contenu qui clignote à certaines fréquences ou selon certains schémas peut
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}
 
@@ -532,14 +562,16 @@ Un contenu bien organisé permet aux utilisateurs de s’orienter et de naviguer
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 2.4 -
     Navigable](http://www.w3.org/WAI/WCAG20/quickref/#navigation-mechanisms)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 2.2 - Sequential
     navigation](https://www.w3.org/TR/UAAG20/#gl-sequential-navigation)
@@ -552,7 +584,7 @@ Un contenu bien organisé permet aux utilisateurs de s’orienter et de naviguer
 -   [Guideline 2.7 - Graphical
     controls](https://www.w3.org/TR/UAAG20/#gl-configure-controls)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -568,7 +600,9 @@ Un contenu bien organisé permet aux utilisateurs de s’orienter et de naviguer
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -577,12 +611,12 @@ Un contenu bien organisé permet aux utilisateurs de s’orienter et de naviguer
 
 {% include excol.html type="middle" %}
 
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Luis, assistant en supermarché, atteint du syndrome de Down]({{ "/people-use-web/user-stories.fr/" | relative_url }}#supermarketassistant)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="supermarketassistant" text="Luis, assistant en supermarché, atteint du syndrome de Down" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -607,14 +641,16 @@ Les auteurs de contenus doivent s’assurer que le contenu textuel est lisible e
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 3.1 -
     Readable](http://www.w3.org/WAI/WCAG20/quickref/#meaning)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -625,7 +661,9 @@ Les auteurs de contenus doivent s’assurer que le contenu textuel est lisible e
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -634,11 +672,11 @@ Les auteurs de contenus doivent s’assurer que le contenu textuel est lisible e
 
 {% include excol.html type="middle" %}
 
--   [Martine, étudiante en ligne, malentendante]({{ "/people-use-web/user-stories.fr/" | relative_url }}#onlinestudent)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Luis, assistant en supermarché, atteint du syndrome de Down]({{ "/people-use-web/user-stories.fr/" | relative_url }}#supermarketassistant)
+-   {% include link.html to="/people-use-web/user-stories/" id="onlinestudent" text="Martine, étudiante en ligne, malentendante" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="supermarketassistant" text="Luis, assistant en supermarché, atteint du syndrome de Down" %}
 
 {% include excol.html type="end" %}
 
@@ -659,19 +697,21 @@ Un grand nombre de personnes s’appuie sur des interfaces prévisibles et est d
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 3.2 -
     Predictable](http://www.w3.org/WAI/WCAG20/quickref/#consistent-behavior)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 3.3 -
     Predictable](https://www.w3.org/TR/UAAG20/#gl-predictable-operation)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -685,7 +725,9 @@ Un grand nombre de personnes s’appuie sur des interfaces prévisibles et est d
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -694,12 +736,12 @@ Un grand nombre de personnes s’appuie sur des interfaces prévisibles et est d
 
 {% include excol.html type="middle" %}
 
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Luis, assistant en supermarché, atteint du syndrome de Down]({{ "/people-use-web/user-stories.fr/" | relative_url }}#supermarketassistant)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="supermarketassistant" text="Luis, assistant en supermarché, atteint du syndrome de Down" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 
@@ -720,19 +762,21 @@ Les formulaires et d’autres systèmes interactifs peuvent induire de la confus
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 3.3 - Input
     assistance](http://www.w3.org/WAI/WCAG20/quickref/#minimize-error)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 3.1 -
     Mistakes](https://www.w3.org/TR/UAAG20/#gl-avoid-mistakes)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -746,7 +790,9 @@ Les formulaires et d’autres systèmes interactifs peuvent induire de la confus
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -755,11 +801,11 @@ Les formulaires et d’autres systèmes interactifs peuvent induire de la confus
 
 {% include excol.html type="middle" %}
 
--   [Lee, client de site Web marchand, daltonien]({{ "/people-use-web/user-stories.fr/" | relative_url }}#shopper)
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme]({{ "/people-use-web/user-stories.fr/" | relative_url }}#retiree)
--   [Luis, assistant en supermarché, atteint du syndrome de Down]({{ "/people-use-web/user-stories.fr/" | relative_url }}#supermarketassistant)
+-   {% include link.html to="/people-use-web/user-stories/" id="shopper" text="Lee, client de site Web marchand, daltonien" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="retiree" text="Yun, retraité avec une mauvaise vue, un tremblement des mains, et une perte de mémoire à court terme" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="supermarketassistant" text="Luis, assistant en supermarché, atteint du syndrome de Down" %}
 
 {% include excol.html type="end" %}
 
@@ -782,14 +828,16 @@ Un contenu robuste est compatible avec de multiples navigateurs, outils d’assi
 
 {% include excol.html type="middle" %}
 
-<div lang="en">
+{::nomarkdown}
+{% include lang.html type="start" lang="en" %}
+{:/}
 
-**WCAG 2.0**
+**WCAG**
 
 -   [Guideline 4.1 -
     Compatible](http://www.w3.org/WAI/WCAG20/quickref/#ensure-compat)
 
-**UAAG 2.0**
+**UAAG**
 
 -   [Guideline 2.6 - Preference
     settings](https://www.w3.org/TR/UAAG20/#gl-store-prefs)
@@ -798,7 +846,7 @@ Un contenu robuste est compatible avec de multiples navigateurs, outils d’assi
 -   [Guideline 5.1 - Follow
     specifications](https://www.w3.org/TR/UAAG20/#gl-obs-env-conventions)
 
-**ATAG 2.0**
+**ATAG**
 
 -   [Principle A.1: Authoring tool user interfaces follow applicable
     accessibility
@@ -806,7 +854,9 @@ Un contenu robuste est compatible avec de multiples navigateurs, outils d’assi
 -   [Part B. Support the production of accessible
     content](https://www.w3.org/TR/ATAG20/#part_b)
 
-</div>
+{::nomarkdown}
+{% include lang.html type="end" %}
+{:/}
 
 {% include excol.html type="end" %}{% include excol.html type="start" %}
 
@@ -815,12 +865,12 @@ Un contenu robuste est compatible avec de multiples navigateurs, outils d’assi
 
 {% include excol.html type="middle" %}
 
--   [Lee, client de site Web marchand, daltonien]({{ "/people-use-web/user-stories.fr/" | relative_url }}#shopper)
--   [Alex, journaliste avec un trouble musculosquelettique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#reporter)
--   [Ilya, cadre supérieure, aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#accountant)
--   [Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique]({{ "/people-use-web/user-stories.fr/" | relative_url }}#classroomstudent)
--   [Luis, assistant en supermarché, atteint du syndrome de Down]({{ "/people-use-web/user-stories.fr/" | relative_url }}#supermarketassistant)
--   [Kaseem, adolescente qui est sourde et aveugle]({{ "/people-use-web/user-stories.fr/" | relative_url }}#teenager)
+-   {% include link.html to="/people-use-web/user-stories/" id="shopper" text="Lee, client de site Web marchand, daltonien" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="reporter" text="Alex, journaliste avec un trouble musculosquelettique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="accountant" text="Ilya, cadre supérieure, aveugle" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="classroomstudent" text="Preety, élève de collège avec un trouble du déficit de l'attention avec hyperactivité et dyslexique" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="supermarketassistant" text="Luis, assistant en supermarché, atteint du syndrome de Down" %}
+-   {% include link.html to="/people-use-web/user-stories/" id="teenager" text="Kaseem, adolescente qui est sourde et aveugle" %}
 
 {% include excol.html type="end" %}
 

--- a/index.md
+++ b/index.md
@@ -3,6 +3,7 @@ title: Accessibility Principles
 permalink: /fundamentals/accessibility-principles/
 ref: /fundamentals/accessibility-principles/
 lang: en
+last_updated: 2019-01-09
 github:
   repository: w3c/wai-accessibility-principles
 layout: default
@@ -56,7 +57,7 @@ of these include:
 -   **User agents**{:#useragents} - software that people use to access
     web content, including desktop graphical browsers, voice browsers,
     mobile phone browsers, multimedia players, plug-ins, and some
-    [assistive technologies]({{ "/people-use-web/tools-techniques/" | relative_url }}#at "definition").
+    [assistive technologies]({{ "/people-use-web/tools-techniques/" | relative_url }}#at).
 -   **Authoring tools**{:#authoringtools} - software or services that
     people use to produce web content, including code editors, document
     conversion tools, content management systems, blogs, database
@@ -99,7 +100,7 @@ accessibility. These include:
     (ATAG)]({{ "/standards-guidelines/atag/" | relative_url }})**
 
 There is also a WAI specification for **[Accessible Rich Internet
-Applications (WAI-ARIA)](https://www.w3.org/WAI/intro/aria.php)**, which
+Applications (WAI-ARIA)]({{ "/standards-guidelines/aria/" | relative_url }})**, which
 include dynamic content and advanced user interface controls developed
 with Ajax, JavaScript, and related web technologies.
 
@@ -355,7 +356,7 @@ a proper design that provides sufficient color contrast between text and
 its surrounding background. For others, audio that is automatically
 played could interfere with text-to-speech or with [assistive listening
 devices
-(ALDs)](http://www.w3.org/WAI/training/accessible#ald "definition").
+(ALDs)](http://www.w3.org/WAI/training/accessible#ald).
 
 {% include excol.html type="start" %}
 


### PR DESCRIPTION
@notabene @slhenry 

Here’s the preview, see a lot of changes in the files, but mainly implementing the automatic linker. Here in the preview the How People With Disabilities use the web resources are displayed as “(en englais)” although when the document is used on the site where HPWDUTW is available in French, that note should be hidden. Those updates will be automatic then.

@notabene Can you spot-check so I didn’t destroy anything?

https://deploy-preview-10--wai-accessibility-principles.netlify.com/fundamentals/accessibility-principles/fr/